### PR TITLE
Release 1.1.1

### DIFF
--- a/Anime4K.py
+++ b/Anime4K.py
@@ -76,6 +76,7 @@ Example:
 parser.add_argument("-al", "--audio_language", required=False, type=str,
                     help=
                     '''Set this to the audio track language for the output video.
+Supported values are ISO 639-2 three-letter language codes.
 This will not do anything if "--softaudio" is used.''')
 parser.add_argument("--delete_failures", required=False,
                     action='store_true',

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -53,9 +53,9 @@ parser.add_argument("-sd", "--shader_dir", required=False, type=str,
                     help="Path to shader folder")
 parser.add_argument("-bit", "--bit", required=False,
                     action='store_true',
-                    help="Set this flag if the source file is 10bit when using shader")
+                    help="Set this flag if the source file is 10bit when using mode shader")
 parser.add_argument("-i", "--input", required=False, action='append',
-                    help="The input file/directory")
+                    help="Input file/directory")
 parser.add_argument("-o", "--output", required=False,
                     help="Output filename/directory")
 parser.add_argument("-sz", "--split_length", required=False, type=int,
@@ -63,13 +63,13 @@ parser.add_argument("-sz", "--split_length", required=False, type=int,
 parser.add_argument("-ss", "--softsubs", required=False,
                     action='store_true',
                     default=False,
-                    help="Set this flag if you want to manually mux subtitles when using shader")
+                    help="Set this flag if you want to manually mux subtitles when using mode shader")
 parser.add_argument("-sa", "--softaudio", required=False,
                     action='store_true',
                     default=False,
-                    help="Set this flag if you want to manually mux audio when using shader")
+                    help="Set this flag if you want to manually mux audio when using mode shader")
 parser.add_argument("-sm", "--skip_menus", required=False, type=str2dict,
-                    help='''Skip shader/encoding choice menus when using shader
+                    help='''Skip shader/encoding choice menus when using mode shader
 Example:
  --skip_menus="shader=4,encoder=cpu,codec=h264,preset=fast,crf=23"
  --skip_menus="shader=4,encoder=nvenc,codec=hevc,preset=fast,qp=24"''')
@@ -77,6 +77,10 @@ parser.add_argument("-al", "--audio_language", required=False, type=str,
                     help=
                     '''Set this to the audio track language for the output video.
 This will not do anything if "--softaudio" is used.''')
+parser.add_argument("--delete_failures", required=False,
+                    action='store_true',
+                    default=False,
+                    help="Set this flag to delete output files that have failed to compile when using mode multi")
 
 args = vars(parser.parse_args())
 if args['version']:
@@ -152,7 +156,7 @@ elif mode == "multi":
     if type(fn) is str:
         fn = [fn]
     multi(fn, args['width'], args['height'], args['shader_dir'], args['bit'],
-          args['skip_menus'], output)
+          args['skip_menus'], args['delete_failures'], output)
 elif mode == "split":
     length = get_video_length(fn)
     split_by_seconds(filename=fn, split_length=args['split_length'],

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -4,9 +4,9 @@ import sys
 
 from extract_audio import extract_audio
 from extract_subs import extract_subs
+from multi import multi
 from mux import mux
 from shader import shader
-from multi import multi
 from splitter import split_by_seconds, get_video_length
 from utils import __current_version__, is_tool, credz, str2dict
 
@@ -152,7 +152,7 @@ elif mode == "multi":
     if type(fn) is str:
         fn = [fn]
     multi(fn, args['width'], args['height'], args['shader_dir'], args['bit'],
-          args['skip_menus'])
+          args['skip_menus'], output)
 elif mode == "split":
     length = get_video_length(fn)
     split_by_seconds(filename=fn, split_length=args['split_length'],

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -131,7 +131,7 @@ if mode == "audio" or mode == "subs":
         else:
             if not output.endswith("/"):
                 output = output + "/"
-elif mode == "mux" or mode == "shader":
+elif mode == "mux" or mode == "shader" or mode == "multi":
     output = args['output'] or "out.mkv"
 elif mode == "split":
     output = args['output']

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ changes. The differences between Anime4K-Encode-4.0.1 and this repository are:
   for the option "--alang".
 - Renamed `--file` to `--input` as it supports directories
 - Added support for multiple `--input` arguments
-- Use "shader" as the default mode
-- Use 3840x2160 as the default output WxH
-- Use "./shaders" as the default shaders path
+- Added `-m multi` which will apply mode shaders, audio, subs and mux all at
+  once.
+- Use default values for some arguments
 
 ## Installing / Getting started
 

--- a/README.md
+++ b/README.md
@@ -20,30 +20,20 @@ profiles!
 is a repository based
 on [Anime4K-PyWrapper](https://github.com/ThoughtfulDev/Anime4K) that updates
 the [Anime4K](https://github.com/bloc97/Anime4K) shaders used and other
-changes. The differences between Anime4K-Encode-4.0.1 and this repository are:
+changes. The key differences between Anime4K-Encode-4.0.1 and this repository
+are:
 
 - Cleaned up code
-- Re-added NVENC support
-- Added AMD GPU encoding support (completely untested)
+- Re-added NVENC support and added AMD GPU encoding support (completely
+  untested)
 - Re-added 10-bit toggling support
 - Removed official support for videos with a resolution lower than FHD
 - Added support for MP4 files
 - Ability to choose to manually mux subtitles and audio via `--softsubs`
-  and `--softaudio`
+  and `--softaudio`. You can also use `-m multi` which will apply mode shaders
+  with `--softsubs` and `--softaudio`, audio, subs and mux all at once.
 - Ability to skip menus in shader mode via `--skip_menus`
-- `-o`/`--output` works for subs and audio mode
-  <br><b>Note</b>: You must run `mux` mode in the directory these files are
-  located, as there is no command line argument to specify subs and audio
-  locations.
-- Added `-al=<lang>`/`--audio_language=<lang>` which will select the language
-  track to burn in (`--softaudio` will disable this). Supported values are ISO
-  639-2 three-letter language codes as
-  stated [here](https://github.com/mpv-player/mpv/blob/master/DOCS/man/options.rst)
-  for the option "--alang".
-- Renamed `--file` to `--input` as it supports directories
 - Added support for multiple `--input` arguments
-- Added `-m multi` which will apply mode shaders, audio, subs and mux all at
-  once.
 - Use default values for some arguments
 
 ## Installing / Getting started

--- a/extract_audio.py
+++ b/extract_audio.py
@@ -10,13 +10,15 @@ from simple_term_menu import TerminalMenu
 from utils import current_date, language_mapping
 
 
-def extract_audio(fn: str, out_dir: str):
+def extract_audio(fn: str, out_dir: str) -> bool:
     """
     Extract audio from a media file.
 
     Args:
         fn: input media file path
         out_dir: directory where audio files are extracted to
+    Returns:
+        True if the audio tracks were successfully extracted
     """
 
     if out_dir is None:
@@ -24,6 +26,7 @@ def extract_audio(fn: str, out_dir: str):
 
     print("Loading file={0}".format(fn))
     mkv = MKVFile(fn)
+    success = True
 
     # Extract tracks from input media
     print("Audio extraction start time: " + current_date())
@@ -33,8 +36,9 @@ def extract_audio(fn: str, out_dir: str):
             ext = track._track_codec
             lang = language_mapping[track._language]
             id = str(track._track_id)
+            return_code = -1
             try:
-                subprocess.call([
+                return_code = subprocess.call([
                     'mkvextract', 'tracks', fn,
                     id + ':' + out_dir + lang + '.' + ext
                 ])
@@ -45,6 +49,8 @@ def extract_audio(fn: str, out_dir: str):
                     sys.exit(-1)
                 except SystemExit:
                     os._exit(-1)
+            if return_code != 0:
+                success = False
 
     print("Audio extraction end time: " + current_date())
 
@@ -100,3 +106,4 @@ def extract_audio(fn: str, out_dir: str):
                 time.sleep(1)
                 os.remove(f)
             print("Conversion end time: " + current_date())
+    return success

--- a/extract_subs.py
+++ b/extract_subs.py
@@ -19,13 +19,15 @@ def genExt(codec):
         return None
 
 
-def extract_subs(fn: str, out_dir: str):
+def extract_subs(fn: str, out_dir: str) -> bool:
     """
     Extract subtitles from a media file.
 
     Args:
         fn: input media file path
         out_dir: directory where subtitles are extracted to
+    Returns:
+        True if the subtitles were successfully extracted
     """
 
     if out_dir is None:
@@ -36,6 +38,7 @@ def extract_subs(fn: str, out_dir: str):
 
     print("Subtitle extraction start time: " + current_date())
     tracks = mkv.get_track()
+    success = True
     for track in tracks:
         if track.track_type == 'subtitles':
             ext = genExt(track._track_codec)
@@ -48,8 +51,9 @@ def extract_subs(fn: str, out_dir: str):
             lang = track._language
             id = str(track._track_id)
 
+            return_code = -1
             try:
-                subprocess.call([
+                return_code = subprocess.call([
                     'mkvextract', 'tracks', fn,
                     id + ':' + str(out_dir) + str(lang) + '_' + id + '.' + ext
                 ])
@@ -57,4 +61,7 @@ def extract_subs(fn: str, out_dir: str):
                 print("Cancelled subtitles extraction.")
                 print("Exiting program...")
                 sys.exit(-1)
+            if return_code != 0:
+                success = False
     print("Subtitle extraction end time: " + current_date())
+    return success

--- a/multi.py
+++ b/multi.py
@@ -27,6 +27,8 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
 
     """
 
+    if skip_menus is None:
+        skip_menus = {}
     encoded_files = shader(fn=fn, width=width, height=height,
                            shader_path=shader_path,
                            ten_bit=ten_bit, language="", softsubs=True,

--- a/multi.py
+++ b/multi.py
@@ -38,6 +38,8 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
         print()
         print("error: no files encoded, terminating program early...")
         sys.exit(-2)
+
+    successful_inputs = {}
     failed_inputs = []
     for input_path, output_path in encoded_files.items():
         print()
@@ -68,21 +70,24 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
         except Exception as e:
             print("Failed to mux file={0}".format(output_path))
             print(e)
-            print("Skipping...")
+            print("Deleting encoded file and skipping...")
+            os.remove(output_path)
             failed_inputs.append(input_path)
             continue
         os.remove(output_path)
         print("Successfully compiled file={0}".format(new_output))
+        successful_inputs[input_path] = new_output
     print()
-    if len(failed_inputs) == 0:
+
+    if len(successful_inputs) > 0:
         print(
             "All of the following input files have been encoded and compiled:")
-        print("\n".join(encoded_files.keys()))
-    elif len(failed_inputs) == len(encoded_files):
-        print("Failed to compile the encoded input files.")
-        print("Please try manually muxing the following encoded files:")
-        print("\n".join(failed_inputs))
-    else:
-        print("Some of the encoded input files have been compiled.")
-        print("Failed to compile the following encoded input files:")
-        print("\n".join(failed_inputs))
+        for input_path, output_path in successful_inputs.items():
+            print(" {0} => {1}".format(input_path, output_path))
+    if len(failed_inputs) > 0:
+        print()
+        if len(failed_inputs) == len(encoded_files):
+            print("Failed to compile all encoded input files.")
+        else:
+            print("Failed to compile the following encoded input files:")
+            print("\n".join(failed_inputs))

--- a/multi.py
+++ b/multi.py
@@ -93,6 +93,8 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
             failed_inputs.append(input_path)
             continue
         os.remove(output_path)
+        os.rename(new_output, output_path)
+        new_output = output_path
         print("Successfully compiled file={0}".format(new_output))
         successful_inputs[input_path] = new_output
     print()

--- a/multi.py
+++ b/multi.py
@@ -1,0 +1,85 @@
+import os
+import sys
+
+from extract_audio import extract_audio
+from extract_subs import extract_subs
+from mux import clean_up, mux
+from shader import shader
+
+
+def multi(fn: "list[str]", width: int, height: int, shader_path: str,
+          ten_bit: bool, skip_menus: dict, outname: str):
+    """
+    Run mode shader on the input files, then for each file successfully
+    encoded with shaders applied, run extract audio and extract subs on
+    the original input file, and finally mux the encoded file with the
+    extracted subs and audio track files.
+
+    Args:
+        fn: list of input files
+        width: desired width of video
+        height: desired height of video
+        shader_path: path where the shaders are located
+        ten_bit: true if the input file(s) are a 10 bit source
+        skip_menus: menu skipping options passed from command line
+        outname: output path
+    Returns:
+
+    """
+
+    encoded_files = shader(fn=fn, width=width, height=height,
+                           shader_path=shader_path,
+                           ten_bit=ten_bit, language="", softsubs=True,
+                           softaudio=True,
+                           skip_menus=skip_menus, outname=outname)
+    if len(encoded_files) == 0:
+        print()
+        print("error: no files encoded, terminating program early...")
+        sys.exit(-2)
+    failed_inputs = []
+    for input_path, output_path in encoded_files.items():
+        print()
+        print("Starting mode subs for input={0}".format(input_path))
+        if not extract_subs(input_path, ""):
+            clean_up()
+            print(
+                "Failed to extract subtitles for file={0}".format(input_path)
+            )
+            failed_inputs.append(input_path)
+            continue
+        print()
+        print("Starting mode audio for input={0}".format(input_path))
+        if not extract_audio(input_path, ""):
+            clean_up()
+            print(
+                "Failed to extract audio for file={0}".format(input_path)
+            )
+            failed_inputs.append(input_path)
+            continue
+        print()
+
+        new_output = os.path.splitext(output_path)[0] + "-mux.mkv"
+        print("Starting mode mux for input={0}, output={1}".format(output_path,
+                                                                   new_output))
+        try:
+            mux(output_path, new_output)
+        except Exception as e:
+            print("Failed to mux file={0}".format(output_path))
+            print(e)
+            print("Skipping...")
+            failed_inputs.append(input_path)
+            continue
+        print("Successfully compiled file={0}".format(new_output))
+    print()
+    if len(failed_inputs) == 0:
+        print(
+            "All of the following input files have been encoded and compiled:")
+        print("\n".join(encoded_files.keys()))
+    elif len(failed_inputs) == len(encoded_files):
+        print("Failed to compile the encoded input files.")
+        print("Please try manually muxing the following encoded files:")
+        print("\n".join(failed_inputs))
+    else:
+        print("Some of the encoded input files have been compiled.")
+        print("Failed to compile the following encoded input files:")
+        print("\n".join(failed_inputs))

--- a/multi.py
+++ b/multi.py
@@ -69,6 +69,7 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
             print("Skipping...")
             failed_inputs.append(input_path)
             continue
+        os.remove(output_path)
         print("Successfully compiled file={0}".format(new_output))
     print()
     if len(failed_inputs) == 0:

--- a/shader.py
+++ b/shader.py
@@ -281,7 +281,8 @@ def shader(fn: "list[str]", width: int, height: int, shader_path: str,
             codec = "hevc"
             encoder = "amf"
         else:
-            print("Cancel")
+            print("Cancelled")
+            shader_cleanup()
             sys.exit(-2)
 
     return start_encoding(codec, encoder, width, height, shader_path, ten_bit,
@@ -373,6 +374,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
                                                  title="Choose Encoder Preset:").show()
             if selected_codec_preset is None:
                 print("Cancelled")
+                shader_cleanup()
                 sys.exit(-1)
             codec_preset = codec_presets[selected_codec_preset]
 
@@ -458,6 +460,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
             encoding_args.append("--ovc=libx265")
         else:
             print("ERROR: Unknown codec: {0}".format(codec))
+            shader_cleanup()
             sys.exit(-2)
 
         encoding_args.append(

--- a/shader.py
+++ b/shader.py
@@ -289,19 +289,24 @@ def shader(fn: "list[str]", width: int, height: int, shader_path: str,
                           files)
 
 
-def handle_encoding_cancellation(file_name: str, start_time: str):
+def handle_encoding_cancellation(file_name: str, output_file, start_time: str):
     """
     Handle cancellation during encoding
 
     Args:
         file_name: The current file being encoded
+        output_file: The output file to delete
         start_time: The time the first file began encoding
     """
 
     print("Cancelled encoding of file={0}".format(file_name))
     print("Start time: {0}".format(start_time))
     print("End time: " + current_date())
+    print()
+    print("Deleting temporary files...")
     shader_cleanup()
+    if output_file is not None:
+        os.remove(output_file)
     print("Exiting program...")
     try:
         sys.exit(-1)
@@ -497,7 +502,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
                 encoding_args + ['--o=' + outname, "temp.mkv"]
             )
         except KeyboardInterrupt:
-            handle_encoding_cancellation(files[0], start_time)
+            handle_encoding_cancellation(files[0], outname, start_time)
         print("End time: " + current_date())
         os.remove("temp.mkv")
         print()
@@ -530,7 +535,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
                     "temp.mkv"
                 ])
             except KeyboardInterrupt:
-                handle_encoding_cancellation(f, start_time)
+                handle_encoding_cancellation(f, output_path, start_time)
             if return_code != 0:
                 failed_files.append(f)
             else:

--- a/shader.py
+++ b/shader.py
@@ -158,7 +158,7 @@ def remove_audio_and_subs(fn: str, softsubs: bool, softaudio: bool):
         subprocess.call(args)
     except KeyboardInterrupt:
         print("File processing cancelled for file={0}".format(fn))
-        cleanup()
+        shader_cleanup()
         print("Exiting program...")
         try:
             sys.exit(-1)
@@ -166,7 +166,7 @@ def remove_audio_and_subs(fn: str, softsubs: bool, softaudio: bool):
             os._exit(-1)
 
 
-def cleanup():
+def shader_cleanup():
     """
     Post-encoding cleanup
     """
@@ -301,7 +301,7 @@ def handle_encoding_cancellation(file_name: str, start_time: str):
     print("Cancelled encoding of file={0}".format(file_name))
     print("Start time: {0}".format(start_time))
     print("End time: " + current_date())
-    cleanup()
+    shader_cleanup()
     print("Exiting program...")
     try:
         sys.exit(-1)
@@ -499,6 +499,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
         except KeyboardInterrupt:
             handle_encoding_cancellation(files[0], start_time)
         print("End time: " + current_date())
+        os.remove("temp.mkv")
         print()
         if return_code == 0:
             successful_encodes[files[0]] = outname
@@ -536,6 +537,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
                 successful_encodes[f] = output_path
             print("End time for file={0}: {1}".format(str(i + 1),
                                                       current_date()))
+            os.remove("temp.mkv")
             clear()
             i = i + 1
         print("Files: {0}".format(files_string))

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from shutil import which
 
-__current_version__ = '1.1.0'
+__current_version__ = '1.1.1-SNAPSHOT'
 
 
 def credz():

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from shutil import which
 
-__current_version__ = '1.1.1-SNAPSHOT'
+__current_version__ = '1.1.1'
 
 
 def credz():


### PR DESCRIPTION
# Release 1.1.1

## Changes
- Support `-m multi` which runs `-m shader --softsubs --softaudio` followed by `-m audio`, `-m subs` and finally `-m mux` for each encoded input file
- Add `--delete_failures` which deletes encoded input files that have failed to compile when using `-m multi`
- Clean up README
- Delete temp.mkv if user cancels when using `-m shader`
- Delete partially encoded output file if encoding is cancelled when using `-m shader` 