### PR TITLE
Release 1.1.2

### DIFF
--- a/Anime4K.py
+++ b/Anime4K.py
@@ -82,6 +82,8 @@ parser.add_argument("--delete_failures", required=False,
                     action='store_true',
                     default=False,
                     help="Set this flag to delete output files that have failed to compile when using mode multi")
+parser.add_argument("-si", "--skip_input", required=False, action='append',
+                    help="Input file to skip when using a directory as an input for modes shader and multi")
 
 args = vars(parser.parse_args())
 if args['version']:
@@ -147,17 +149,24 @@ elif mode == "subs":
     extract_subs(fn, output)
 elif mode == "mux":
     mux(fn, output)
-elif mode == "shader":
+elif mode == "shader" or mode == "multi":
     if type(fn) is str:
         fn = [fn]
-    shader(fn, args['width'], args['height'], args['shader_dir'], args['bit'],
-           args['audio_language'], args['softsubs'], args['softaudio'],
-           args['skip_menus'] or {}, output)
-elif mode == "multi":
-    if type(fn) is str:
-        fn = [fn]
-    multi(fn, args['width'], args['height'], args['shader_dir'], args['bit'],
-          args['skip_menus'], args['delete_failures'], output)
+    skip_inputs = args['skip_input']
+    if skip_inputs is None:
+        skip_inputs = []
+    elif type(skip_inputs) is str:
+        skip_inputs = [skip_inputs]
+
+    if mode == "shader":
+        shader(fn, skip_inputs, args['width'], args['height'],
+               args['shader_dir'], args['bit'], args['audio_language'],
+               args['softsubs'], args['softaudio'], args['skip_menus'] or {},
+               output)
+    else:
+        multi(fn, skip_inputs, args['width'], args['height'],
+              args['shader_dir'], args['bit'], args['skip_menus'],
+              args['delete_failures'], output)
 elif mode == "split":
     length = get_video_length(fn)
     split_by_seconds(filename=fn, split_length=args['split_length'],

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -144,7 +144,7 @@ if mode == "audio" or mode == "subs":
         output = ""
     if output != "":
         if not os.path.isdir(output):
-            print("Output directory {0} does not exist".format(output))
+            print("error: output directory {0} does not exist".format(output))
             sys.exit(-2)
         else:
             if not output.endswith("/"):
@@ -160,7 +160,7 @@ elif mode in MODES_SUPPORTING_MULTI_INPUTS:
             print(e)
             sys.exit(-2)
 else:
-    output = args['output']
+    output = args['output'] or "out.mkv"
 
 # Collect input file paths from the input argument(s)
 in_files = []

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -177,7 +177,7 @@ elif mode == "shader" or mode == "multi":
     if mode == "shader":
         shader(fn, skip_inputs, args['width'], args['height'],
                args['shader_dir'], args['bit'], args['audio_language'],
-               args['softsubs'], args['softaudio'], skip_menus, output)
+               args['softsubs'], args['softaudio'], skip_menus, True, output)
     else:
         multi(fn, skip_inputs, args['width'], args['height'],
               args['shader_dir'], args['bit'], skip_menus,

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -76,6 +76,8 @@ parser.add_argument("-sm", "--skip_menus", required=False, type=str2dict,
 Examples for mode shader:
  --skip_menus="shader=4,encoder=cpu,codec=h264,preset=fast,crf=23"
  --skip_menus="shader=4,encoder=nvenc,codec=hevc,preset=fast,qp=24"
+Example for mode audio:
+ --skip_menus="convert=0"
 Example for mode encode:
  --skip_menus="encode=0"''')
 parser.add_argument("-al", "--audio_language", required=False, type=str,
@@ -152,7 +154,11 @@ else:
     output = args['output']
 
 if mode == "audio":
-    extract_audio(fn, output)
+    skip_menus = args['skip_menus']
+    if skip_menus is None:
+        skip_menus = {}
+
+    extract_audio(fn, output, skip_menus)
 elif mode == "subs":
     extract_subs(fn, output)
 elif mode == "mux":

--- a/Anime4K.py
+++ b/Anime4K.py
@@ -106,6 +106,7 @@ def exit_if_missing(file_path: str, allow_dir: bool = True):
     elif allow_dir is False:
         print("error: cannot use a directory ({0}) as an input for this mode"
               .format(file_path))
+        sys.exit(-2)
 
 
 fn = args['input']

--- a/extract_audio.py
+++ b/extract_audio.py
@@ -71,6 +71,9 @@ def extract_audio(fn: str, out_dir: str) -> bool:
                     title="What's the format of the file? => {0}".format(f)
                 )
                 br_choice = br_menu.show()
+                if br_choice is None:
+                    print("Cancelled conversion")
+                    continue
                 if br_choice == 0:
                     br = "192K"
                 elif br_choice == 1:
@@ -81,8 +84,9 @@ def extract_audio(fn: str, out_dir: str) -> bool:
                     br = "192K"
                 fn_base = f.split(".")[0]
                 out_audio = fn_base + ".Opus"
+                return_code = -1
                 try:
-                    subprocess.call([
+                    return_code = subprocess.call([
                         "ffmpeg",
                         "-hide_banner",
                         "-i",
@@ -98,12 +102,8 @@ def extract_audio(fn: str, out_dir: str) -> bool:
                 except KeyboardInterrupt:
                     print("Cancelled conversion.")
                     os.remove(out_audio)
-                    print("Exiting program...")
-                    try:
-                        sys.exit(-1)
-                    except SystemExit:
-                        os._exit(-1)
                 time.sleep(1)
-                os.remove(f)
+                if return_code == 0:
+                    os.remove(f)
             print("Conversion end time: " + current_date())
     return success

--- a/multi.py
+++ b/multi.py
@@ -38,7 +38,6 @@ def multi(input_files: "list[str]", width: int, height: int, shader_path: str,
                            exit_on_cancel=False, outname=outname)
     clear()
     if len(encoded_files) == 0:
-        print()
         print("error: no files encoded, terminating program early...")
         sys.exit(-2)
     else:

--- a/multi.py
+++ b/multi.py
@@ -8,8 +8,7 @@ from shader import shader
 from utils import clear
 
 
-def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
-          shader_path: str,
+def multi(input_files: "list[str]", width: int, height: int, shader_path: str,
           ten_bit: bool, skip_menus: dict, del_failures: bool, outname: str):
     """
     Run mode shader on the input files, then for each file successfully
@@ -18,8 +17,7 @@ def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
     extracted subs and audio track files.
 
     Args:
-        fn: list of input files
-        skip_inputs: list of input files to skip
+        input_files: list of input media files
         width: desired width of video
         height: desired height of video
         shader_path: path where the shaders are located
@@ -33,9 +31,9 @@ def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
 
     if skip_menus is None:
         skip_menus = {}
-    encoded_files = shader(fn=fn, skip_inputs=skip_inputs, width=width,
-                           height=height, shader_path=shader_path,
-                           ten_bit=ten_bit, language="", softsubs=True,
+    encoded_files = shader(input_files=input_files, width=width, height=height,
+                           shader_path=shader_path, ten_bit=ten_bit,
+                           language="", softsubs=True,
                            softaudio=True, skip_menus=skip_menus,
                            exit_on_cancel=False, outname=outname)
     clear()

--- a/multi.py
+++ b/multi.py
@@ -5,6 +5,7 @@ from extract_audio import extract_audio
 from extract_subs import extract_subs
 from mux import clean_up, mux
 from shader import shader
+from utils import clear
 
 
 def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
@@ -36,11 +37,14 @@ def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
                            height=height, shader_path=shader_path,
                            ten_bit=ten_bit, language="", softsubs=True,
                            softaudio=True, skip_menus=skip_menus,
-                           outname=outname)
+                           exit_on_cancel=False, outname=outname)
+    clear()
     if len(encoded_files) == 0:
         print()
         print("error: no files encoded, terminating program early...")
         sys.exit(-2)
+    else:
+        print("Encoded files: {0}".format(", ".join(encoded_files.keys())))
 
     successful_inputs = {}
     failed_inputs = []

--- a/multi.py
+++ b/multi.py
@@ -7,7 +7,8 @@ from mux import clean_up, mux
 from shader import shader
 
 
-def multi(fn: "list[str]", width: int, height: int, shader_path: str,
+def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
+          shader_path: str,
           ten_bit: bool, skip_menus: dict, del_failures: bool, outname: str):
     """
     Run mode shader on the input files, then for each file successfully
@@ -17,6 +18,7 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
 
     Args:
         fn: list of input files
+        skip_inputs: list of input files to skip
         width: desired width of video
         height: desired height of video
         shader_path: path where the shaders are located
@@ -30,11 +32,11 @@ def multi(fn: "list[str]", width: int, height: int, shader_path: str,
 
     if skip_menus is None:
         skip_menus = {}
-    encoded_files = shader(fn=fn, width=width, height=height,
-                           shader_path=shader_path,
+    encoded_files = shader(fn=fn, skip_inputs=skip_inputs, width=width,
+                           height=height, shader_path=shader_path,
                            ten_bit=ten_bit, language="", softsubs=True,
-                           softaudio=True,
-                           skip_menus=skip_menus, outname=outname)
+                           softaudio=True, skip_menus=skip_menus,
+                           outname=outname)
     if len(encoded_files) == 0:
         print()
         print("error: no files encoded, terminating program early...")

--- a/multi.py
+++ b/multi.py
@@ -61,7 +61,7 @@ def multi(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
             continue
         print()
         print("Starting mode audio for input={0}".format(input_path))
-        if not extract_audio(input_path, ""):
+        if not extract_audio(input_path, "", skip_menus):
             print(
                 "Failed to extract audio for file={0}".format(input_path)
             )

--- a/shader.py
+++ b/shader.py
@@ -174,15 +174,15 @@ def shader_cleanup():
     os.remove("temp.mkv")
 
 
-def shader(fn: "list[str]", width: int, height: int, shader_path: str,
-           ten_bit: bool,
-           language: str, softsubs: bool, softaudio: bool, skip_menus: dict,
-           outname: str) -> dict:
+def shader(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
+           shader_path: str, ten_bit: bool, language: str, softsubs: bool,
+           softaudio: bool, skip_menus: dict, outname: str) -> dict:
     """
     Select encoding and start the encoding process.
 
     Args:
         fn: list of input media paths
+        skip_inputs: list of input media paths to skip
         width: output width
         height: output height
         shader_path: path the shaders are located at
@@ -205,10 +205,16 @@ def shader(fn: "list[str]", width: int, height: int, shader_path: str,
     files = []
     for file in fn:
         if os.path.isdir(file):
-            for fileInDir in glob.glob(os.path.join(file, "*.mkv")):
-                files.append(os.path.join(fileInDir))
-            for fileInDir in glob.glob(os.path.join(file, "*.mp4")):
-                files.append(os.path.join(fileInDir))
+            for file_in_dir in glob.glob(os.path.join(file, "*.mkv")):
+                file_name = os.path.basename(file_in_dir)
+                if file_name in skip_inputs:
+                    continue
+                files.append(os.path.join(file_in_dir))
+            for file_in_dir in glob.glob(os.path.join(file, "*.mp4")):
+                file_name = os.path.basename(file_in_dir)
+                if file_name in skip_inputs:
+                    continue
+                files.append(os.path.join(file_in_dir))
         else:
             files.append(os.path.join(file))
     file_count = len(files)

--- a/shader.py
+++ b/shader.py
@@ -134,7 +134,7 @@ def menu_fhd_shaders(shader_path: str, skip_menus: dict) -> str:
 
 # Core
 
-def remove_audio_and_subs(fn: str, softsubs: bool, softaudio: bool):
+def remove_audio_and_subs(fn: str, softsubs: bool, softaudio: bool) -> int:
     """
     Remove audio and optionally subtitles from a file.
 
@@ -142,6 +142,8 @@ def remove_audio_and_subs(fn: str, softsubs: bool, softaudio: bool):
         fn: media file path
         softsubs: true if subtitles should be removed
         softaudio: true if audio should be removed
+    Returns:
+        return code of the merge process
     """
 
     args = [
@@ -156,7 +158,7 @@ def remove_audio_and_subs(fn: str, softsubs: bool, softaudio: bool):
     args.append(fn)
 
     try:
-        subprocess.call(args)
+        return subprocess.call(args)
     except KeyboardInterrupt:
         print("File processing cancelled for file={0}".format(fn))
         shader_cleanup()
@@ -233,16 +235,16 @@ def shader(input_files: "list[str]", width: int, height: int, shader_path: str,
         sys.exit(-2)
 
     output_is_dir = os.path.isdir(outname)
-    if len(input_files) == 1 and output_is_dir:
-        new_outname = os.path.join(outname, "out.mkv")
-        out_name_index = 1
-        while os.path.exists(new_outname):
-            new_outname = os.path.join(outname, "out-{0}.mkv"
-                                       .format(str(out_name_index)))
-            out_name_index = out_name_index + 1
-        outname = new_outname
-        output_is_dir = False
-
+    if len(input_files) == 1:
+        if output_is_dir:
+            new_outname = os.path.join(outname, "out.mkv")
+            out_name_index = 1
+            while os.path.exists(new_outname):
+                new_outname = os.path.join(outname, "out-{0}.mkv"
+                                           .format(str(out_name_index)))
+                out_name_index = out_name_index + 1
+            outname = new_outname
+            output_is_dir = False
         remove_audio_and_subs(input_files[0], softsubs, softaudio)
         clear()
 

--- a/shader.py
+++ b/shader.py
@@ -285,7 +285,13 @@ Would you like to overwrite the input files?'''.format(
     else:
         clear()
         if output_is_dir:
-            outname = os.path.join(outname, "out.mkv")
+            new_outname = os.path.join(outname, "out.mkv")
+            out_name_index = 1
+            while os.path.exists(new_outname):
+                new_outname = os.path.join(outname, "out-{0}.mkv"
+                                           .format(str(out_name_index)))
+                out_name_index = out_name_index + 1
+            outname = new_outname
         remove_audio_and_subs(files[0], softsubs, softaudio)
         clear()
 

--- a/shader.py
+++ b/shader.py
@@ -530,7 +530,15 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
             name = name[len(name) - 1]
             remove_audio_and_subs(f, softsubs, softaudio)
             clear()
-            print("Files: {0}".format(files_string))
+            print("Encoded files: {0}".format(
+                ", ".join(successful_encodes.keys())))
+            print("Remaining files: {0}".format(", ".join(
+                [
+                    item for item in files
+                    if
+                    item not in failed_files and item not in successful_encodes
+                ]
+            )))
             print("Start time: {0}".format(start_time))
             print("Start time for file={0}: {1}".format(str(i + 1),
                                                         current_date()))

--- a/shader.py
+++ b/shader.py
@@ -24,10 +24,12 @@ def menu_fhd_shaders(shader_path: str, skip_menus: dict) -> str:
     """
 
     mode_choice = None
-    if "shader" in skip_menus and skip_menus['shader'] is not None:
+    if "shader" in skip_menus:
         mode_choice = int(skip_menus['shader'])
         if mode_choice < 0 or mode_choice > 5:
             mode_choice = None
+    elif "recommended" in skip_menus and skip_menus['recommended'] == "1":
+        mode_choice = 4
     if mode_choice is None:
         mode_menu = TerminalMenu(
             [
@@ -237,12 +239,15 @@ def shader(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
     codec = ""
     encoder = ""
 
-    if "encoder" in skip_menus and skip_menus['encoder'] is not None:
+    if "encoder" in skip_menus:
         encoder = skip_menus['encoder']
         if encoder != 'cpu' and encoder != 'nvenc' and encoder != 'amf':
             print("Unsupported encoder: {0}".format(encoder))
             sys.exit(-2)
-    if "codec" in skip_menus and skip_menus['codec'] is not None:
+    if encoder == "":
+        if "recommended" in skip_menus and skip_menus["recommended"] == "1":
+            encoder = "cpu"
+    if "codec" in skip_menus:
         codec = skip_menus['codec']
         if codec == 'x264':
             codec = 'h264'
@@ -255,6 +260,9 @@ def shader(fn: "list[str]", skip_inputs: "list[str]", width: int, height: int,
         if codec != 'h264' and codec != 'hevc':
             print("Unsupported codec={0}".format(encoder))
             sys.exit(-2)
+    if codec == "":
+        if "recommended" in skip_menus and skip_menus["recommended"] == "1":
+            codec = "h264"
     if codec == "" or encoder == "":
         cg_menu = TerminalMenu(
             [
@@ -371,10 +379,12 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
         elif encoder == "nvenc":
             codec_presets = ["fast", "medium", "slow", "lossless"]
         codec_preset = None
-        if "preset" in skip_menus and skip_menus['preset'] is not None:
+        if "preset" in skip_menus:
             codec_preset = skip_menus['preset']
             if codec_preset not in codec_presets:
                 codec_preset = None
+        elif "recommended" in skip_menus and skip_menus["recommended"] == "1":
+            codec_preset = "fast"
         if codec_preset is None:
             selected_codec_preset = TerminalMenu(codec_presets,
                                                  title="Choose Encoder Preset:").show()
@@ -386,7 +396,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
 
     comp_level = ""
     if encoder == "cpu":
-        if "crf" in skip_menus and skip_menus['crf'] is not None:
+        if "crf" in skip_menus:
             crf = int(skip_menus['crf'])
             if 0 <= crf <= 51:
                 comp_level = str(crf)
@@ -394,6 +404,8 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
                 comp_level = "23"
                 print("Invalid crf provided, using default crf={0}".format(
                     comp_level))
+        elif "recommended" in skip_menus and skip_menus["recommended"] == "1":
+            comp_level = "23"
         else:
             comp_level = input(
                 "Insert compression factor (CRF) 0-51\n0 = Lossless | 23 = Default | 51 = Highest compression\n"
@@ -401,7 +413,7 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
             if comp_level == "" or comp_level is None:
                 comp_level = "23"
     elif encoder == "nvenc" or encoder == "amf":
-        if "qp" in skip_menus and skip_menus['qp'] is not None:
+        if "qp" in skip_menus:
             qp = int(skip_menus['qp'])
             if 0 <= qp <= 51:
                 comp_level = str(qp)
@@ -409,6 +421,8 @@ def start_encoding(codec: str, encoder: str, width: int, height: int,
                 comp_level = "24"
                 print("Invalid qp provided, using default qp={0}".format(
                     comp_level))
+        elif "recommended" in skip_menus and skip_menus["recommended"] == "1":
+            comp_level = "24"
         else:
             comp_level = input(
                 "Insert Quantization Parameter (QP) 0-51\n0 = Lossless | 24 = Default | 51 = Highest compression\n"

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from shutil import which
 
-__current_version__ = '1.1.2-SNAPSHOT'
+__current_version__ = '1.1.2'
 
 
 def credz():

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from shutil import which
 
-__current_version__ = '1.1.1'
+__current_version__ = '1.1.2-SNAPSHOT'
 
 
 def credz():


### PR DESCRIPTION
# Release 1.1.2

## Additions
- Support `-m encode` like the original Anime4K-Encoder does, encoding input files with certain presets
- Add `--skip_inputs` which allows ignoring input files when using directories as inputs
- Add `recommended=1` to `--skip_menus` which automatically chooses ideal settings unless the setting is explicitly overriden via skip_menus

## Changes
- Use a default path during mode mux
- Print remaining files when using multiple inputs during mode shader